### PR TITLE
Bump lru to 0.7.8 to mitigate vulnerabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ license = "MIT"
 description = "A memory-based wrapper around the lru crate"
 
 [dependencies]
-lru = "0.6"
+lru = "0.7.8"


### PR DESCRIPTION
Signed-off-by: Dengjianping <djptux@gmail.com>

This pallet is being used in polkadot, so all parachains will be affected.

https://github.com/paritytech/polkadot/blob/master/node/core/runtime-api/Cargo.toml#L10

See the security report: https://rustsec.org/advisories/RUSTSEC-2021-0130.html
And  related issue: https://github.com/jeromefroe/lru-rs/issues/120